### PR TITLE
Define ruby dependency for bundler

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -62,7 +62,9 @@ class robby (
     home_directory => $robby_home_directory,
   }
 
-  class { 'robby::ruby': }
+  class { 'robby::ruby': 
+    before => Class['bundler'],
+  }
 
   class { 'robby::packages':
     require => Class['robby::ruby'],


### PR DESCRIPTION
Previous to this commit, there was no explicit relationship between
Class['bundler'] and Class['robby::ruby'].  This caused bundler to be
installed prior to ruby 1.9 being set up.  That in turn caused all the
gems for the Robby application to be installed in ruby 1.8 path and
therefor unavailable to the application.

This commit creates an explicit dependency between the classes which
resolves the above issues.
