### PR TITLE
Manage the guess_results directory

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -39,7 +39,7 @@ class robby (
     mode   => '0755',
   }
 
-  file { '/var/log/robby':
+  file { ['/var/log/robby','/var/log/robby/guess_results']:
     ensure => directory,
     mode   => '0755',
   }


### PR DESCRIPTION
This commit ensures the /var/log/robby/guess_results directory is present and
owned by the same user the unicorn process is run as
