### PR TITLE
Fix "name" field in metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-  "robby": "puppetlabs-robby",
+  "name": "puppetlabs-robby",
   "version": "0.1",
   "license": "Internal",
   "source": "https://github.com/puppetlabs/puppetlabs-robby",


### PR DESCRIPTION
The field that should be called "name" is called "robby".

Without this, the PE 2015.2.1 upgrade fails because the metadata file gets parsed but the resulting ruby object does not have a name attribute.
